### PR TITLE
[EEPD-24912] Fixed terminating when there is a message in the queue.

### DIFF
--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -434,7 +434,7 @@ class InviteDialog(DialogBase):
 
     async def wait_for_terminate(self, timeout=10):
         try:
-            while not self._waiter.done():
+            while not (self._waiter.done() and self._queue.empty()):
                 yield await asyncio.wait_for(self._queue.get(), timeout)
         except asyncio.TimeoutError:
             LOG.warning("Timeout during wait a response from the server")

--- a/aiosip/protocol.py
+++ b/aiosip/protocol.py
@@ -28,7 +28,6 @@ class UDP(asyncio.DatagramProtocol):
             self.transport.sendto(msg.encode(), addr)
 
     def connection_lost(self, error):
-        LOG.error("Connection lost %s", error)
         self.app._connection_lost(self)
 
     def connection_made(self, transport):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='aiosip',
-    version='0.2.2',
+    version='0.2.3',
     description='SIP support for AsyncIO',
     long_description=readme + '\n\n' + history,
     author='Ludovic Gasc (GMLudo)',


### PR DESCRIPTION
https://eagleeyenetworks.atlassian.net/browse/EEPD-24912

This can fix the Mobotix move camera. 

The problem is the camera sends 100, 101, 180, 200 very quickly. aiosip inserted all messages into queue without waiting for consuming the messages. So there is possibility the queue has [101, 180, 200] and self._waiter.done() is True. In this case, the last message was 101 when self._queue.get() return the message. 